### PR TITLE
docs: add README usage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,38 @@
 # 2K MyPLAYER Tracker
 
-A small web app for manually tracking NBA 2K MyPLAYER builds over time.
+2K MyPLAYER Tracker is a lightweight web app for manually tracking NBA 2K MyPLAYER builds over time.
 
-## Features
-- Create, edit and delete builds with position, body settings and attributes.
+## Functionality
+
+- Create, edit, and delete builds with position, body settings, and attributes.
 - View all saved builds and manage them from a list.
-- Compare two builds side‑by‑side with a table and radar chart.
+- Compare two builds side by side with a table and radar chart.
 - Export builds as JSON and import them later.
-- Data persists locally using `localStorage` (no backend required).
+- Data persists locally using `localStorage`; no backend setup is required.
+
+## Running Locally
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Start the development server**
+   ```bash
+   npm run dev
+   ```
+   This boots a Vite dev server (default: http://localhost:5173) where the app will be available.
+
+## Build for Production
+
+```bash
+npm run build
+```
+
+Use `npm run preview` to locally serve the production build.
 
 ## Tech Stack
+
 - React + TypeScript + Vite
 - Tailwind CSS for styling
 - React Router for navigation
 - Chart.js via `react-chartjs-2` for comparison charts
-
-## Development
-```bash
-npm install
-npm run dev
-```
-
-## Build
-```bash
-npm run build
-```


### PR DESCRIPTION
## Summary
- document app functionality
- outline steps to install dependencies and run the dev server locally

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e6b31bf3c8322be5d8b0753ebc3fc