### PR TITLE
feat: add Google authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_GOOGLE_CLIENT_ID=your-google-client-id

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Environment variables
+.env
+.env.*
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@
 - Export builds as JSON and import them later.
 - Data persists locally using `localStorage`; no backend setup is required.
 
+## Authentication
+
+Sign in with Google is required to use the app. Create a Google OAuth client and set the client ID in a `.env` file:
+
+```
+cp .env.example .env
+# edit .env and set VITE_GOOGLE_CLIENT_ID
+```
+
+The development and production builds will use this client ID for Google authentication.
+
 ## Running Locally
 
 1. **Install dependencies**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-app",
       "version": "0.0.0",
       "dependencies": {
+        "@react-oauth/google": "^0.12.2",
         "chart.js": "^4.5.0",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
@@ -1408,6 +1409,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.2.tgz",
+      "integrity": "sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@react-oauth/google": "^0.12.2",
     "chart.js": "^4.5.0",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,11 @@ import BuildListPage from './pages/BuildListPage'
 import BuildFormPage from './pages/BuildFormPage'
 import ComparePage from './pages/ComparePage'
 import BoxScorePage from './pages/BoxScorePage'
+import { useAuth } from './AuthProvider'
 
 function App() {
+  const { logout } = useAuth()
+
   return (
     <div className="min-h-screen bg-gray-900 text-gray-100">
       <nav className="bg-gray-800 p-4 flex gap-4">
@@ -12,6 +15,9 @@ function App() {
         <Link to="/new" className="hover:underline">New Build</Link>
         <Link to="/compare" className="hover:underline">Compare</Link>
         <Link to="/box-score" className="hover:underline">Box Score</Link>
+        <button onClick={logout} className="ml-auto hover:underline">
+          Sign Out
+        </button>
       </nav>
       <div className="p-4">
         <Routes>

--- a/src/AuthProvider.tsx
+++ b/src/AuthProvider.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, type ReactNode } from 'react'
+import { GoogleLogin } from '@react-oauth/google'
+
+interface AuthContextType {
+  user: string | null
+  login: (credential: string) => void
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  login: () => {},
+  logout: () => {},
+})
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<string | null>(null)
+
+  const login = (credential: string) => setUser(credential)
+  const logout = () => setUser(null)
+
+  if (!user) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-gray-900">
+        <GoogleLogin
+          onSuccess={(cred) => login(cred.credential ?? '')}
+          onError={() => console.log('Login Failed')}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  return useContext(AuthContext)
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,19 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { GoogleOAuthProvider } from '@react-oauth/google'
 import './index.css'
 import App from './App.tsx'
+import { AuthProvider } from './AuthProvider'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+      <BrowserRouter>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </BrowserRouter>
+    </GoogleOAuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- require Google sign-in before accessing the tracker
- wire up Google OAuth provider and auth context
- document client ID setup and sample env file

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688eaf8af88c83229f272feb6913c8a6