### PR TITLE
feat: enhance frontend styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,15 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
     <title>2K MyPLAYER Tracker</title>
   </head>
-  <body class="bg-gray-900 text-gray-100">
+  <body class="bg-gray-900 text-gray-100 font-sans">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,16 +10,27 @@ function App() {
 
   return (
     <div className="min-h-screen bg-gray-900 text-gray-100">
-      <nav className="bg-gray-800 p-4 flex gap-4">
-        <Link to="/" className="font-bold">2K MyPLAYER Tracker</Link>
-        <Link to="/new" className="hover:underline">New Build</Link>
-        <Link to="/compare" className="hover:underline">Compare</Link>
-        <Link to="/box-score" className="hover:underline">Box Score</Link>
-        <button onClick={logout} className="ml-auto hover:underline">
+      <nav className="bg-gray-800/50 backdrop-blur p-4 shadow flex flex-wrap items-center gap-4">
+        <Link to="/" className="font-bold text-xl">
+          2K MyPLAYER Tracker
+        </Link>
+        <Link to="/new" className="hover:underline">
+          New Build
+        </Link>
+        <Link to="/compare" className="hover:underline">
+          Compare
+        </Link>
+        <Link to="/box-score" className="hover:underline">
+          Box Score
+        </Link>
+        <button
+          onClick={logout}
+          className="ml-auto px-4 py-2 rounded font-semibold bg-gray-700 text-white hover:bg-gray-600 transition-colors"
+        >
           Sign Out
         </button>
       </nav>
-      <div className="p-4">
+      <div className="p-4 max-w-4xl mx-auto">
         <Routes>
           <Route path="/" element={<BuildListPage />} />
           <Route path="/new" element={<BuildFormPage />} />

--- a/src/components/BuildCard.tsx
+++ b/src/components/BuildCard.tsx
@@ -8,24 +8,24 @@ interface Props {
 
 export default function BuildCard({ build, onDelete }: Props) {
   return (
-    <div className="bg-gray-800 p-4 rounded flex justify-between items-center">
+    <div className="bg-gray-800 p-4 rounded shadow flex justify-between items-center">
       <div>
         <h3 className="text-lg font-bold">{build.name}</h3>
-        <p className="text-sm">
+        <p className="text-sm text-gray-400">
           {build.game} — {build.position}
         </p>
-        <p className="text-sm">{build.archetype}</p>
+        <p className="text-sm text-gray-400">{build.archetype}</p>
       </div>
       <div className="flex gap-2">
         <Link
           to={`/build/${build.id}`}
-          className="px-2 py-1 bg-blue-600 rounded"
+          className="px-4 py-2 rounded font-semibold bg-blue-600 text-white hover:bg-blue-700 transition-colors"
         >
           View
         </Link>
         <button
           onClick={() => onDelete(build.id)}
-          className="px-2 py-1 bg-red-600 rounded"
+          className="px-4 py-2 rounded font-semibold bg-red-600 text-white hover:bg-red-700 transition-colors"
         >
           Delete
         </button>

--- a/src/components/BuildForm.tsx
+++ b/src/components/BuildForm.tsx
@@ -72,7 +72,10 @@ export default function BuildForm({ build, onSave }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-6 bg-gray-800 rounded shadow p-4"
+    >
       <div className="grid grid-cols-2 gap-4">
         <input
           name="name"
@@ -80,7 +83,7 @@ export default function BuildForm({ build, onSave }: Props) {
           onChange={handleChange}
           required
           placeholder="Name"
-          className="p-2 rounded bg-gray-700"
+          className="bg-gray-700 border border-gray-600 rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
         <input
           name="game"
@@ -88,7 +91,7 @@ export default function BuildForm({ build, onSave }: Props) {
           onChange={handleChange}
           required
           placeholder="Game"
-          className="p-2 rounded bg-gray-700"
+          className="bg-gray-700 border border-gray-600 rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
         <input
           name="position"
@@ -96,7 +99,7 @@ export default function BuildForm({ build, onSave }: Props) {
           onChange={handleChange}
           required
           placeholder="Position"
-          className="p-2 rounded bg-gray-700"
+          className="bg-gray-700 border border-gray-600 rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
         <input
           type="number"
@@ -107,7 +110,7 @@ export default function BuildForm({ build, onSave }: Props) {
           min={60}
           max={90}
           placeholder="Height (in)"
-          className="p-2 rounded bg-gray-700"
+          className="bg-gray-700 border border-gray-600 rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
         <input
           type="number"
@@ -118,7 +121,7 @@ export default function BuildForm({ build, onSave }: Props) {
           min={150}
           max={400}
           placeholder="Weight (lbs)"
-          className="p-2 rounded bg-gray-700"
+          className="bg-gray-700 border border-gray-600 rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
         <input
           type="number"
@@ -129,7 +132,7 @@ export default function BuildForm({ build, onSave }: Props) {
           min={70}
           max={90}
           placeholder="Wingspan (in)"
-          className="p-2 rounded bg-gray-700"
+          className="bg-gray-700 border border-gray-600 rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
         <input
           name="archetype"
@@ -137,14 +140,14 @@ export default function BuildForm({ build, onSave }: Props) {
           onChange={handleChange}
           required
           placeholder="Archetype"
-          className="p-2 rounded bg-gray-700 col-span-2"
+          className="bg-gray-700 border border-gray-600 rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500 col-span-2"
         />
       </div>
       <h3 className="text-lg font-bold">Attributes</h3>
       <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
         {attributeKeys.map((attr) => (
           <div key={attr} className="flex flex-col">
-            <label className="text-sm capitalize">
+            <label className="text-sm capitalize mb-1">
               {attr.replace(/([A-Z])/g, ' $1')}
             </label>
             <input
@@ -155,12 +158,15 @@ export default function BuildForm({ build, onSave }: Props) {
               min={0}
               max={99}
               required
-              className="p-2 rounded bg-gray-700"
+              className="bg-gray-700 border border-gray-600 rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
         ))}
       </div>
-      <button type="submit" className="px-4 py-2 bg-blue-600 rounded">
+      <button
+        type="submit"
+        className="px-4 py-2 rounded font-semibold bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+      >
         Save Build
       </button>
     </form>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+

--- a/src/pages/BoxScorePage.tsx
+++ b/src/pages/BoxScorePage.tsx
@@ -43,28 +43,28 @@ function BoxScorePage() {
   }, [username])
 
   return (
-    <div>
-      <h1 className="text-xl font-bold mb-4">Upload Final Box Score</h1>
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Upload Final Box Score</h1>
 
-      <div className="mb-4 space-y-2">
+      <div className="space-y-2 bg-gray-800 rounded shadow p-4 max-w-sm">
         <input
           type="text"
           placeholder="Username"
           value={username}
           onChange={(e) => setUsername(e.target.value)}
-          className="text-black p-1"
+          className="bg-gray-700 border border-gray-600 rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500 w-full"
         />
         <input type="file" accept="image/*" onChange={handleFileChange} />
       </div>
 
-      {loading && <p className="mt-4">Reading screenshot...</p>}
+      {loading && <p>Reading screenshot...</p>}
 
       {preview && (
-        <img src={preview} alt="preview" className="mt-4 max-w-xs border" />
+        <img src={preview} alt="preview" className="max-w-xs border rounded" />
       )}
 
       {stats && !loading && (
-        <div className="mt-4 space-y-1">
+        <div className="space-y-1 bg-gray-800 rounded shadow p-4 max-w-sm">
           <p>Points: {stats.points}</p>
           <p>Rebounds: {stats.rebounds}</p>
           <p>Assists: {stats.assists}</p>
@@ -85,11 +85,11 @@ function BoxScorePage() {
               type="date"
               value={dateInput}
               onChange={(e) => setDateInput(e.target.value)}
-              className="text-black mt-2 p-1"
+              className="bg-gray-700 border border-gray-600 rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2"
             />
           )}
           <button
-            className="mt-2 px-2 py-1 bg-blue-600 rounded"
+            className="px-4 py-2 rounded font-semibold bg-blue-600 text-white hover:bg-blue-700 transition-colors mt-2"
             onClick={handleSave}
           >
             Save
@@ -98,7 +98,7 @@ function BoxScorePage() {
       )}
 
       {history.length > 0 && (
-        <div className="mt-8">
+        <div className="mt-8 bg-gray-800 rounded shadow p-4 max-w-sm">
           <h2 className="font-bold mb-2">History</h2>
           <ul className="space-y-1">
             {history.map((h) => (

--- a/src/pages/BuildFormPage.tsx
+++ b/src/pages/BuildFormPage.tsx
@@ -18,7 +18,7 @@ export default function BuildFormPage() {
   }
 
   return (
-    <div>
+    <div className="max-w-2xl mx-auto">
       <BuildForm build={build} onSave={handleSave} />
     </div>
   )

--- a/src/pages/BuildListPage.tsx
+++ b/src/pages/BuildListPage.tsx
@@ -47,15 +47,25 @@ export default function BuildListPage() {
   return (
     <div className="space-y-4">
       <div className="flex gap-2">
-        <button onClick={handleExport} className="px-2 py-1 bg-green-600 rounded">
+        <button
+          onClick={handleExport}
+          className="px-4 py-2 rounded font-semibold bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+        >
           Export JSON
         </button>
-        <label className="px-2 py-1 bg-gray-700 rounded cursor-pointer">
+        <label
+          className="px-4 py-2 rounded font-semibold bg-gray-700 text-white hover:bg-gray-600 transition-colors cursor-pointer"
+        >
           Import JSON
-          <input type="file" accept="application/json" onChange={handleImport} className="hidden" />
+          <input
+            type="file"
+            accept="application/json"
+            onChange={handleImport}
+            className="hidden"
+          />
         </label>
       </div>
-      {builds.length === 0 && <p>No builds saved.</p>}
+      {builds.length === 0 && <p className="text-gray-400">No builds saved.</p>}
       <div className="space-y-2">
         {builds.map((b) => (
           <BuildCard key={b.id} build={b} onDelete={handleDelete} />

--- a/src/pages/ComparePage.tsx
+++ b/src/pages/ComparePage.tsx
@@ -17,11 +17,11 @@ export default function ComparePage() {
 
   return (
     <div className="space-y-4">
-      <div className="flex gap-4">
+      <div className="flex flex-col sm:flex-row gap-4">
         <select
           value={firstId}
           onChange={(e) => setFirstId(e.target.value)}
-          className="p-2 bg-gray-700 rounded"
+          className="bg-gray-700 border border-gray-600 rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           {builds.map((b) => (
             <option key={b.id} value={b.id}>
@@ -32,7 +32,7 @@ export default function ComparePage() {
         <select
           value={secondId}
           onChange={(e) => setSecondId(e.target.value)}
-          className="p-2 bg-gray-700 rounded"
+          className="bg-gray-700 border border-gray-600 rounded p-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
         >
           {builds.map((b) => (
             <option key={b.id} value={b.id}>
@@ -43,7 +43,7 @@ export default function ComparePage() {
       </div>
       {first && second && (
         <>
-          <div className="overflow-auto">
+          <div className="overflow-auto bg-gray-800 rounded shadow p-4">
             <table className="min-w-full text-sm">
               <thead>
                 <tr>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,7 +3,11 @@ import type { Config } from 'tailwindcss'
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 } satisfies Config


### PR DESCRIPTION
## Summary
- add Inter font and use it across the app
- refresh navigation and page layouts with responsive Tailwind styles
- unify form, button, and card styling for a consistent UI

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ecee8bc708322bb4fe8b745780780