### PR TITLE
style: refresh UI with gradient and polished cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,9 @@
     />
     <title>2K MyPLAYER Tracker</title>
   </head>
-  <body class="bg-gray-900 text-gray-100 font-sans">
+  <body
+    class="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-gray-100 font-sans"
+  >
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,8 @@ function App() {
   const { logout } = useAuth()
 
   return (
-    <div className="min-h-screen bg-gray-900 text-gray-100">
-      <nav className="bg-gray-800/50 backdrop-blur p-4 shadow flex flex-wrap items-center gap-4">
+    <div className="min-h-screen text-gray-100 bg-black/30 backdrop-blur-sm">
+      <nav className="bg-gradient-to-r from-blue-700/70 to-purple-700/70 backdrop-blur p-4 shadow flex flex-wrap items-center gap-4 rounded-b">
         <Link to="/" className="font-bold text-xl">
           2K MyPLAYER Tracker
         </Link>

--- a/src/components/BuildCard.tsx
+++ b/src/components/BuildCard.tsx
@@ -8,13 +8,13 @@ interface Props {
 
 export default function BuildCard({ build, onDelete }: Props) {
   return (
-    <div className="bg-gray-800 p-4 rounded shadow flex justify-between items-center">
+    <div className="p-4 rounded-lg shadow-md bg-gray-800/60 backdrop-blur border border-gray-700 flex justify-between items-center hover:shadow-lg transition-shadow">
       <div>
         <h3 className="text-lg font-bold">{build.name}</h3>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-300">
           {build.game} — {build.position}
         </p>
-        <p className="text-sm text-gray-400">{build.archetype}</p>
+        <p className="text-sm text-gray-300">{build.archetype}</p>
       </div>
       <div className="flex gap-2">
         <Link


### PR DESCRIPTION
## Summary
- add a gradient background for a more dynamic feel
- style navigation bar with color blend and translucency
- polish build cards with subtle blur, border, and softer text

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ed2659ee48322a86e7c0aad359145