### PR TITLE
Display builds in table

### DIFF
--- a/src/pages/BuildListPage.tsx
+++ b/src/pages/BuildListPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { ChangeEvent } from 'react'
-import BuildCard from '../components/BuildCard'
+import { Link } from 'react-router-dom'
 import type { Build } from '../types'
 import { getBuilds, deleteBuild, saveBuilds } from '../utils/storage'
 
@@ -66,11 +66,45 @@ export default function BuildListPage() {
         </label>
       </div>
       {builds.length === 0 && <p className="text-gray-400">No builds saved.</p>}
-      <div className="space-y-2">
-        {builds.map((b) => (
-          <BuildCard key={b.id} build={b} onDelete={handleDelete} />
-        ))}
-      </div>
+      {builds.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-700">
+            <thead>
+              <tr className="text-left">
+                <th className="px-4 py-2">Name</th>
+                <th className="px-4 py-2">Game</th>
+                <th className="px-4 py-2">Position</th>
+                <th className="px-4 py-2">Archetype</th>
+                <th className="px-4 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-700">
+              {builds.map((b) => (
+                <tr key={b.id}>
+                  <td className="px-4 py-2">{b.name}</td>
+                  <td className="px-4 py-2">{b.game}</td>
+                  <td className="px-4 py-2">{b.position}</td>
+                  <td className="px-4 py-2">{b.archetype}</td>
+                  <td className="px-4 py-2 space-x-2">
+                    <Link
+                      to={`/build/${b.id}`}
+                      className="px-3 py-1 rounded font-semibold bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+                    >
+                      View
+                    </Link>
+                    <button
+                      onClick={() => handleDelete(b.id)}
+                      className="px-3 py-1 rounded font-semibold bg-red-600 text-white hover:bg-red-700 transition-colors"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace build list cards with a responsive table

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ee06054488322aa9578b53fdbeaf0