### PR TITLE
Fix parsing of box score screenshots

### DIFF
--- a/src/utils/parseBoxScore.ts
+++ b/src/utils/parseBoxScore.ts
@@ -1,11 +1,15 @@
 import Tesseract from 'tesseract.js'
 import type { ParsedBoxScore } from '../types'
 
+function escapeRegExp(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 export async function parseBoxScore(image: File | string, username: string): Promise<ParsedBoxScore> {
   const { data: { text } } = await Tesseract.recognize(image, 'eng')
 
   const lineRegex = new RegExp(
-    `${username}\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)-(\\d+)\\s+(\\d+)-(\\d+)\\s+(\\d+)-(\\d+)\\s+([^\\s]+)`,
+    `${escapeRegExp(username)}\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)-(\\d+)\\s+(\\d+)-(\\d+)\\s+(\\d+)-(\\d+)\\s+([^\\s]+)`,
     'i'
   )
 
@@ -26,6 +30,6 @@ export async function parseBoxScore(image: File | string, username: string): Pro
     ftm: match ? parseInt(match[10], 10) : 0,
     fta: match ? parseInt(match[11], 10) : 0,
     grade: match ? match[12] : '',
-    date: dateMatch ? dateMatch[1] : '',
+    date: dateMatch ? dateMatch[0] : '',
   }
 }


### PR DESCRIPTION
## Summary
- handle usernames with special regex characters when extracting stats from screenshots
- correctly capture detected game dates from OCR text

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ee90be0808322badd44f5a06d62cd