### PR TITLE
feat: use backend API for box score parsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ VITE_FIREBASE_PROJECT_ID=your-project-id
 VITE_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
 VITE_FIREBASE_MESSAGING_SENDER_ID=your-sender-id
 VITE_FIREBASE_APP_ID=your-app-id
+VITE_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Enable Firestore and Storage in your Firebase project before running the app.
 
 ### OCR Backend
 
-An optional FastAPI server is included for parsing box score screenshots with Tesseract.
+The frontend relies on an optional FastAPI server for parsing box score screenshots with Tesseract. Set the server's base URL in
+your `.env` file using `VITE_API_URL` (defaults to `http://localhost:8000`).
 
 1. **Install system dependency**
 

--- a/src/pages/BoxScorePage.tsx
+++ b/src/pages/BoxScorePage.tsx
@@ -11,6 +11,7 @@ function BoxScorePage() {
   const [history, setHistory] = useState<PlayerGameStats[]>([])
   const [preview, setPreview] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0]
@@ -18,9 +19,15 @@ function BoxScorePage() {
     setFile(f)
     setPreview(URL.createObjectURL(f))
     setLoading(true)
+    setError(null)
     const result = await parseBoxScore(f, username)
-    setStats(result)
-    if (result.date) setDateInput(result.date)
+    if ('error' in result) {
+      setError(result.error)
+      setStats(null)
+    } else {
+      setStats(result)
+      if (result.date) setDateInput(result.date)
+    }
     setLoading(false)
   }
 
@@ -58,6 +65,7 @@ function BoxScorePage() {
       </div>
 
       {loading && <p>Reading screenshot...</p>}
+      {error && !loading && <p className="text-red-500">{error}</p>}
 
       {preview && (
         <img src={preview} alt="preview" className="max-w-xs border rounded" />

--- a/src/utils/parseBoxScore.ts
+++ b/src/utils/parseBoxScore.ts
@@ -1,70 +1,31 @@
-import Tesseract from 'tesseract.js'
 import type { ParsedBoxScore } from '../types'
 
-type OCRWord = {
-  text: string
-  bbox: {
-    x0: number
-    y0: number
-    x1: number
-    y1: number
+/**
+ * Sends a box score image to the backend OCR API and returns parsed stats.
+ */
+export async function parseBoxScore(
+  file: File,
+  username: string
+): Promise<ParsedBoxScore | { error: string }> {
+  const formData = new FormData()
+  formData.append('file', file)
+  formData.append('username', username)
+
+  try {
+    const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+    const response = await fetch(`${baseUrl}/parse-boxscore`, {
+      method: 'POST',
+      body: formData,
+    })
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => null)
+      return { error: (data && data.detail) || 'Failed to parse box score.' }
+    }
+
+    return (await response.json()) as ParsedBoxScore
+  } catch (err) {
+    return { error: (err as Error).message }
   }
 }
 
-export async function parseBoxScore(image: File | string, username: string): Promise<ParsedBoxScore | { error: string }> {
-  const result = await Tesseract.recognize(image, 'eng')
-
-  // Force-cast to access .words, which exists even if not in default types
-  const words = (result.data as any).words as OCRWord[]
-
-  if (!words || words.length === 0) {
-    return { error: 'OCR did not detect any words.' }
-  }
-
-  const targetWord = words.find(w =>
-    w.text.toUpperCase().includes(username.toUpperCase())
-  )
-
-  if (!targetWord) {
-    return { error: `Username "${username}" not found in image.` }
-  }
-
-  const targetY = targetWord.bbox.y0
-
-  const sameLineWords = words.filter(w =>
-    Math.abs(w.bbox.y0 - targetY) <= 10
-  )
-
-  const row = sameLineWords.map(w => w.text).join(' ')
-  console.log('Extracted Row:', row)
-
-  const lineRegex = new RegExp(
-    `${username}\\s+(\\w)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)/(\\d+)\\s+(\\d+)/(\\d+)\\s+(\\d+)/(\\d+)`,
-    'i'
-  )
-
-  const match = row.match(lineRegex)
-
-  if (!match) {
-    return { error: 'Could not parse stat line from detected row.' }
-  }
-
-  return {
-    username,
-    grade: match[1],
-    points: parseInt(match[2]),
-    rebounds: parseInt(match[3]),
-    assists: parseInt(match[4]),
-    steals: parseInt(match[5]),
-    blocks: parseInt(match[6]),
-    fouls: parseInt(match[7]),
-    turnovers: parseInt(match[8]),
-    fgm: parseInt(match[9]),
-    fga: parseInt(match[10]),
-    tpm: parseInt(match[11]),
-    tpa: parseInt(match[12]),
-    ftm: parseInt(match[13]),
-    fta: parseInt(match[14]),
-    date: new Date().toISOString().split('T')[0]
-  }
-}


### PR DESCRIPTION
## Summary
- call backend OCR API to parse box score images
- surface API errors on the box score upload page
- document `VITE_API_URL` for configuring the API URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f7aa08354832288db141e407ce77b