### PR TITLE
Enable CORS for frontend requests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from fastapi import FastAPI, UploadFile, File, HTTPException, Query, Form
+from fastapi.middleware.cors import CORSMiddleware
 import cv2
 import numpy as np
 import sys
@@ -22,6 +23,14 @@ except Exception:  # pragma: no cover
 import pytesseract
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 def preprocess_image(image_bytes: bytes) -> np.ndarray:


### PR DESCRIPTION
## Summary
- allow `http://localhost:5173` origin so the frontend can call the API

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f903abcb083229374d6908e14d5b6