### PR TITLE
fix: accept username in box score uploads

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -93,10 +93,14 @@ def parse_stats(row: str) -> dict:
 @app.post("/parse-boxscore")
 async def parse_boxscore(
     file: UploadFile = File(..., description="PNG or JPEG image"),
-    username: Optional[str] = Query(None, description="Player username"),
-    username_form: Optional[str] = Form(None, description="Player username"),
+    username_query: Optional[str] = Query(
+        None, alias="username", description="Player username"
+    ),
+    username_form: Optional[str] = Form(
+        None, alias="username", description="Player username"
+    ),
 ):
-    user = username or username_form
+    user = username_query or username_form
     if not user:
         raise HTTPException(status_code=400, detail="username is required")
     try:

--- a/backend/tests/test_parse_boxscore.py
+++ b/backend/tests/test_parse_boxscore.py
@@ -1,0 +1,36 @@
+from fastapi.testclient import TestClient
+
+import sys
+from pathlib import Path
+import types
+
+sys.modules["cv2"] = types.SimpleNamespace()
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main import app
+
+
+def fake_preprocess_image(_: bytes) -> str:  # pragma: no cover - simple stub
+    return "stub"
+
+
+def fake_extract_row(_: str, username: str) -> str:  # pragma: no cover - simple stub
+    return f"{username} A 10 5 3 2 1 2 1 5/10 2/5 1/2"
+
+
+def test_username_in_form_is_recognized(monkeypatch) -> None:
+    """Submitting a file with a username should not trigger a missing username error."""
+
+    monkeypatch.setattr("main.preprocess_image", fake_preprocess_image)
+    monkeypatch.setattr("main.extract_row", fake_extract_row)
+
+    client = TestClient(app)
+    response = client.post(
+        "/parse-boxscore",
+        files={"file": ("test.png", b"fake", "image/png")},
+        data={"username": "testuser"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["username"] == "testuser"
+


### PR DESCRIPTION
## Summary
- accept username from either query or form data for `/parse-boxscore`
- add regression test ensuring username provided via form is honored

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f97b18c288322a7c8700c0691458d