### PR TITLE
Handle missing Tesseract gracefully

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -111,4 +111,9 @@ async def parse_boxscore(
         return stats
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except pytesseract.TesseractNotFoundError:
+        raise HTTPException(
+            status_code=500,
+            detail="tesseract is not installed or it's not in your PATH",
+        )
 

--- a/backend/tests/test_parse_boxscore.py
+++ b/backend/tests/test_parse_boxscore.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 import sys
 from pathlib import Path
 import types
+import pytesseract
 
 sys.modules["cv2"] = types.SimpleNamespace()
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -16,6 +17,10 @@ def fake_preprocess_image(_: bytes) -> str:  # pragma: no cover - simple stub
 
 def fake_extract_row(_: str, username: str) -> str:  # pragma: no cover - simple stub
     return f"{username} A 10 5 3 2 1 2 1 5/10 2/5 1/2"
+
+
+def raise_tesseract_error(_: str, __: str) -> str:  # pragma: no cover - simple stub
+    raise pytesseract.TesseractNotFoundError()
 
 
 def test_username_in_form_is_recognized(monkeypatch) -> None:
@@ -33,4 +38,21 @@ def test_username_in_form_is_recognized(monkeypatch) -> None:
 
     assert response.status_code == 200
     assert response.json()["username"] == "testuser"
+
+
+def test_missing_tesseract_returns_500(monkeypatch) -> None:
+    """A clear error is returned when tesseract OCR is unavailable."""
+
+    monkeypatch.setattr("main.preprocess_image", fake_preprocess_image)
+    monkeypatch.setattr("main.extract_row", raise_tesseract_error)
+
+    client = TestClient(app)
+    response = client.post(
+        "/parse-boxscore",
+        files={"file": ("test.png", b"fake", "image/png")},
+        data={"username": "testuser"},
+    )
+
+    assert response.status_code == 500
+    assert "tesseract" in response.json()["detail"].lower()
 


### PR DESCRIPTION
## Summary
- return a clear error when Tesseract OCR is not installed
- add test for missing Tesseract case

## Testing
- `pip install httpx -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9d18e0d8832294ff25e24e1d700d