### PR TITLE
Support plus/minus grades and hyphenated usernames

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -73,7 +73,7 @@ def extract_row(img: np.ndarray, username: str) -> str:
 
 def parse_stats(row: str) -> dict:
     pattern = re.compile(
-        r"^(?P<username>\w+)\s+(?P<grade>[A-F])\s+"\
+        r"^(?P<username>[\w-]+)\s+(?P<grade>[A-F][+-]?)\s+"\
         r"(?P<points>\d+)\s+(?P<rebounds>\d+)\s+(?P<assists>\d+)\s+"\
         r"(?P<steals>\d+)\s+(?P<blocks>\d+)\s+(?P<fouls>\d+)\s+(?P<turnovers>\d+)\s+"\
         r"(?P<fgm>\d+)/(?P<fga>\d+)\s+(?P<tpm>\d+)/(?P<tpa>\d+)\s+(?P<ftm>\d+)/(?P<fta>\d+)"


### PR DESCRIPTION
## Summary
- Allow hyphenated usernames and grades with plus/minus in box score parsing

## Testing
- `python -m py_compile backend/main.py`
- `npm run lint`
- `python - <<'PY'\nfrom backend.main import parse_stats\nrow='Player-1 A+ 10 5 3 1 2 3 4 5/10 2/5 3/4'\nprint(parse_stats(row))\nPY`

------
https://chatgpt.com/codex/tasks/task_e_689d1624e0a48322a193c7f94f5b20d4