### PR TITLE
Add helper to extract player stats from OCR output

### DIFF
--- a/backend/player_stats.py
+++ b/backend/player_stats.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+from typing import List, Dict, Optional, Any
+
+
+def _to_int(value: Any) -> int:
+    """Best-effort conversion of ``value`` to ``int``.
+
+    Any ``TypeError`` or ``ValueError`` results in ``0`` so that callers
+    receive a deterministic structure even when OCR mis-reads a cell.
+    """
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _parse_made_attempted(value: Any) -> tuple[int, int]:
+    """Split a made/attempted string like ``"3/7"`` into integers.
+
+    Invalid or missing values are interpreted as ``0/0``.
+    """
+    try:
+        made, attempted = str(value).split("/", 1)
+        return _to_int(made), _to_int(attempted)
+    except (AttributeError, ValueError):
+        return 0, 0
+
+
+def get_player_stats(rows: List[Dict[str, Any]], username: str) -> Optional[Dict[str, Any]]:
+    """Return the stats for ``username`` from ``rows``.
+
+    Parameters
+    ----------
+    rows:
+        A list of dictionaries as produced by OCR where each dictionary
+        represents a player's row of statistics.  Keys may appear in any
+        case.  Each row must include a ``team`` field identifying either
+        "away" or "home".
+    username:
+        Target username to search for.  Comparison is case-insensitive.
+
+    Returns
+    -------
+    dict | None
+        A dictionary with normalized statistics for the first matching
+        player or ``None`` when no match is found.
+    """
+    target = username.lower()
+    for row in rows:
+        normalized = {k.lower(): v for k, v in row.items()}
+        name = str(normalized.get("username", "")).strip()
+        if name.lower() != target:
+            continue
+
+        fgm, fga = _parse_made_attempted(normalized.get("fgm/fga"))
+        tpm, tpa = _parse_made_attempted(normalized.get("3pm/3pa"))
+        ftm, fta = _parse_made_attempted(normalized.get("ftm/fta"))
+
+        return {
+            "team": normalized.get("team", ""),
+            "username": name,
+            "grade": str(normalized.get("grd", "")),
+            "points": _to_int(normalized.get("pts")),
+            "rebounds": _to_int(normalized.get("reb")),
+            "assists": _to_int(normalized.get("ast")),
+            "steals": _to_int(normalized.get("stl")),
+            "blocks": _to_int(normalized.get("blk")),
+            "fouls": _to_int(normalized.get("fouls")),
+            "turnovers": _to_int(normalized.get("to")),
+            "fgm": fgm,
+            "fga": fga,
+            "three_pm": tpm,
+            "three_pa": tpa,
+            "ftm": ftm,
+            "fta": fta,
+        }
+
+    return None

--- a/backend/tests/test_player_stats.py
+++ b/backend/tests/test_player_stats.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from player_stats import get_player_stats
+
+
+def sample_rows():
+    return [
+        {
+            "team": "away",
+            "username": "AUSWEN",
+            "GRD": "A",
+            "PTS": "21",
+            "REB": "5",
+            "AST": "11",
+            "STL": "2",
+            "BLK": "0",
+            "FOULS": "4",
+            "TO": "0",
+            "FGM/FGA": "9/16",
+            "3PM/3PA": "2/2",
+            "FTM/FTA": "1/2",
+        },
+        {
+            "team": "home",
+            "username": "OtherUser",
+            "GRD": "B+",
+            "PTS": "10",
+            "REB": "4",
+            "AST": "3",
+            "STL": "1",
+            "BLK": "1",
+            "FOULS": "2",
+            "TO": "1",
+            "FGM/FGA": "4/12",
+            "3PM/3PA": "1/4",
+            "FTM/FTA": "1/1",
+        },
+    ]
+
+
+def test_find_player_case_insensitive():
+    stats = get_player_stats(sample_rows(), "auswen")
+    assert stats == {
+        "team": "away",
+        "username": "AUSWEN",
+        "grade": "A",
+        "points": 21,
+        "rebounds": 5,
+        "assists": 11,
+        "steals": 2,
+        "blocks": 0,
+        "fouls": 4,
+        "turnovers": 0,
+        "fgm": 9,
+        "fga": 16,
+        "three_pm": 2,
+        "three_pa": 2,
+        "ftm": 1,
+        "fta": 2,
+    }
+
+
+def test_returns_none_when_missing():
+    assert get_player_stats(sample_rows(), "missing") is None
+
+
+def test_handles_bad_numbers():
+    rows = [
+        {
+            "team": "home",
+            "username": "User",
+            "GRD": "B",
+            "PTS": "N/A",
+            "REB": None,
+            "AST": "3",
+            "STL": "1",
+            "BLK": "1",
+            "FOULS": "2",
+            "TO": "1",
+            "FGM/FGA": "bad",
+            "3PM/3PA": "1/3",
+            "FTM/FTA": "",
+        }
+    ]
+    stats = get_player_stats(rows, "user")
+    assert stats["points"] == 0
+    assert stats["rebounds"] == 0
+    assert stats["fgm"] == 0 and stats["fga"] == 0
+    assert stats["three_pm"] == 1 and stats["three_pa"] == 3
+    assert stats["ftm"] == 0 and stats["fta"] == 0


### PR DESCRIPTION
## Summary
- add `get_player_stats` utility to parse OCR-extracted box score data for a username
- cover new helper with tests for case-insensitive search, error handling and numeric parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d1a8bc9788322bc2fc5d159911182