### PR TITLE
Handle missing stats values

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,6 @@ from fastapi.middleware.cors import CORSMiddleware
 import cv2
 import numpy as np
 import sys
-import re
 from datetime import date
 
 # ``pytesseract`` unconditionally imports :mod:`pandas`, which can fail when
@@ -72,32 +71,71 @@ def extract_row(img: np.ndarray, username: str) -> str:
 
 
 def parse_stats(row: str) -> dict:
-    pattern = re.compile(
-        r"^(?P<username>[\w-]+)\s+(?P<grade>[A-F][+-]?)\s+"\
-        r"(?P<points>\d+)\s+(?P<rebounds>\d+)\s+(?P<assists>\d+)\s+"\
-        r"(?P<steals>\d+)\s+(?P<blocks>\d+)\s+(?P<fouls>\d+)\s+(?P<turnovers>\d+)\s+"\
-        r"(?P<fgm>\d+)/(?P<fga>\d+)\s+(?P<tpm>\d+)/(?P<tpa>\d+)\s+(?P<ftm>\d+)/(?P<fta>\d+)"
-    )
-    match = pattern.match(row)
-    if not match:
+    """Parse a row of OCR text into structured statistics.
+
+    The game client sometimes renders shooting splits either as a single
+    ``made/attempted`` token (e.g. ``"5/12"``) or as two separate tokens
+    (``"5 12"``).  The original regular expression expected the former
+    format exclusively and rejected rows that used the latter.  To make the
+    parser more tolerant, we now tokenise the row and interpret the shooting
+    numbers whether they appear as combined or separate values.
+    """
+
+    tokens = row.split()
+    if len(tokens) < 2:
         raise ValueError("Unable to parse stats row")
-    groups = match.groupdict()
+
+    username, grade = tokens[0], tokens[1]
+
+    def _get(index: int) -> str:
+        return tokens[index] if index < len(tokens) else "0"
+
+    def _to_int(value: str) -> int:
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+
+    points = _to_int(_get(2))
+    rebounds = _to_int(_get(3))
+    assists = _to_int(_get(4))
+    steals = _to_int(_get(5))
+    blocks = _to_int(_get(6))
+    fouls = _to_int(_get(7))
+    turnovers = _to_int(_get(8))
+
+    idx = 9
+
+    def _parse_pair(index: int) -> tuple[int, int, int]:
+        token = _get(index)
+        if "/" in token:
+            made, attempted = token.split("/", 1)
+            return _to_int(made), _to_int(attempted), index + 1
+        else:
+            made = token
+            attempted = _get(index + 1)
+            return _to_int(made), _to_int(attempted), index + 2
+
+    fgm, fga, idx = _parse_pair(idx)
+    tpm, tpa, idx = _parse_pair(idx)
+    ftm, fta, idx = _parse_pair(idx)
+
     return {
-        "username": groups["username"],
-        "grade": groups["grade"],
-        "points": int(groups["points"]),
-        "rebounds": int(groups["rebounds"]),
-        "assists": int(groups["assists"]),
-        "steals": int(groups["steals"]),
-        "blocks": int(groups["blocks"]),
-        "fouls": int(groups["fouls"]),
-        "turnovers": int(groups["turnovers"]),
-        "fgm": int(groups["fgm"]),
-        "fga": int(groups["fga"]),
-        "tpm": int(groups["tpm"]),
-        "tpa": int(groups["tpa"]),
-        "ftm": int(groups["ftm"]),
-        "fta": int(groups["fta"]),
+        "username": username,
+        "grade": grade,
+        "points": points,
+        "rebounds": rebounds,
+        "assists": assists,
+        "steals": steals,
+        "blocks": blocks,
+        "fouls": fouls,
+        "turnovers": turnovers,
+        "fgm": fgm,
+        "fga": fga,
+        "tpm": tpm,
+        "tpa": tpa,
+        "ftm": ftm,
+        "fta": fta,
         "date": date.today().isoformat(),
     }
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ python-multipart
 pytesseract
 opencv-python
 Pillow
+httpx

--- a/backend/tests/test_parse_stats.py
+++ b/backend/tests/test_parse_stats.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main import parse_stats
+
+
+def test_parse_stats_accepts_split_tokens() -> None:
+    row = "AUSWEN A 21 5 11 2 0 4 0 9 16 2 2 1 2"
+    stats = parse_stats(row)
+    assert stats["username"] == "AUSWEN"
+    assert stats["fgm"] == 9 and stats["fga"] == 16
+    assert stats["tpm"] == 2 and stats["tpa"] == 2
+    assert stats["ftm"] == 1 and stats["fta"] == 2
+
+
+def test_parse_stats_tolerates_missing_tokens() -> None:
+    row = "AUSWEN A 10 5 3 2 1 2 3 5/10 2/5"
+    stats = parse_stats(row)
+    assert stats["fta"] == 0 and stats["ftm"] == 0
+


### PR DESCRIPTION
## Summary
- default absent stat tokens to zero instead of erroring
- cover parsing of incomplete rows with a new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acd55573ac8322982a94aedc3b67d1