### PR TITLE
fix: handle stats token offset

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,8 +128,16 @@ def parse_stats(row: str, expected_username: Optional[str] = None) -> dict:
 
 
     def _get(index: int) -> str:
-        idx = start + index
-        return tokens[idx] if idx < len(tokens) else "0"
+        """Safely retrieve a token by index.
+
+        The previous implementation attempted to offset the lookup using an
+        undefined ``start`` variable which resulted in a ``NameError`` during
+        execution.  Since the statistics tokens are already trimmed to begin at
+        the first numeric value, we can simply index directly into the list and
+        return ``"0"`` when the requested index is out of range.
+        """
+
+        return tokens[index] if index < len(tokens) else "0"
 
     def _to_int(value: str) -> int:
         try:


### PR DESCRIPTION
## Summary
- avoid NameError when parsing stats by removing undefined start offset

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68ace3bc65f48322ab63ae5267c667e7