### PR TITLE
Improve OCR reliability for box score uploads

### DIFF
--- a/backend/tests/test_extract_row.py
+++ b/backend/tests/test_extract_row.py
@@ -30,7 +30,7 @@ def test_extract_row_handles_ocr_errors(monkeypatch) -> None:
         "left": list(range(0, 1200, 100)),
     }
 
-    def fake_image_to_data(img, output_type):
+    def fake_image_to_data(img, output_type, **kwargs):
         return fake_data
 
     monkeypatch.setattr(pytesseract, "image_to_data", fake_image_to_data)


### PR DESCRIPTION
## Summary
- upscale images before OCR to better capture small scoreboard numbers
- restrict Tesseract to alphanumeric/score characters for more accurate text detection
- adjust tests for new optional config argument

## Testing
- `pytest`
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ace54d92d0832298771c7888bfa178