### PR TITLE
Handle stray tokens before stats parsing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -133,24 +133,25 @@ def parse_stats(row: str, expected_username: Optional[str] = None) -> dict:
                 tokens.pop(i)
                 break
 
+    def _is_int(token: str) -> bool:
+        try:
+            int(token)
+            return True
+        except ValueError:
+            return False
 
-    def _get(index: int) -> str:
-        """Safely retrieve a token by index.
+    while tokens and not _is_int(tokens[0]):
+        tokens.pop(0)
 
-        The previous implementation attempted to offset the lookup using an
-        undefined ``start`` variable which resulted in a ``NameError`` during
-        execution.  Since the statistics tokens are already trimmed to begin at
-        the first numeric value, we can simply index directly into the list and
-        return ``"0"`` when the requested index is out of range.
-        """
-
-        return tokens[index] if index < len(tokens) else "0"
 
     def _to_int(value: str) -> int:
         try:
             return int(value)
         except ValueError:
             return 0
+
+    def _get(index: int) -> str:
+        return tokens[index] if index < len(tokens) else "0"
 
     points = _to_int(_get(0))
     rebounds = _to_int(_get(1))

--- a/backend/tests/test_parse_stats.py
+++ b/backend/tests/test_parse_stats.py
@@ -30,6 +30,7 @@ def test_parse_stats_accepts_username_first() -> None:
     assert stats["fgm"] == 6 and stats["fga"] == 10
     assert stats["tpm"] == 3 and stats["tpa"] == 5
 
+
 def test_parse_stats_tolerates_missing_tokens() -> None:
     row = "A AUSWEN 10 5 3 2 1 2 3 5/10 2/5"
     stats = parse_stats(row, "AUSWEN")
@@ -43,3 +44,11 @@ def test_parse_stats_accepts_fused_grade_username() -> None:
     assert stats["grade"] == "B-"
     assert stats["points"] == 8
 
+
+def test_parse_stats_skips_non_numeric_prefix() -> None:
+    row = "B; AUSWEN 14 2 3 1 0 0 0 7/14 2/5 1/2"
+    stats = parse_stats(row, "AUSWEN")
+    assert stats["points"] == 14
+    assert stats["rebounds"] == 2
+    assert stats["assists"] == 3
+    assert stats["fgm"] == 7 and stats["fga"] == 14


### PR DESCRIPTION
## Summary
- ignore stray non-numeric OCR tokens before parsing stats
- test parsing when line includes unexpected prefix tokens

## Testing
- `cd backend && pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af1422c16883229a12070eb0aeb658