### PR TITLE
Improve OCR stat parsing robustness

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -133,22 +133,29 @@ def parse_stats(row: str, expected_username: Optional[str] = None) -> dict:
                 tokens.pop(i)
                 break
 
+    def _clean_number(token: str) -> str:
+        """Return a digits-only representation of ``token``.
+
+        OCR output sometimes appends punctuation (e.g. ``"17:"``) or misreads
+        letters that resemble digits.  This helper strips out non-numeric
+        characters and normalises common confusions so that the resulting
+        string can be safely converted to an integer.
+        """
+
+        # Normalise common OCR mistakes where letters are recognised as digits
+        token = token.upper().replace("O", "0").replace("I", "1")
+        # Remove any remaining non-digit characters
+        return re.sub(r"[^0-9]", "", token)
+
     def _is_int(token: str) -> bool:
-        try:
-            int(token)
-            return True
-        except ValueError:
-            return False
+        return bool(_clean_number(token))
 
     while tokens and not _is_int(tokens[0]):
         tokens.pop(0)
 
-
     def _to_int(value: str) -> int:
-        try:
-            return int(value)
-        except ValueError:
-            return 0
+        cleaned = _clean_number(value)
+        return int(cleaned) if cleaned else 0
 
     def _get(index: int) -> str:
         return tokens[index] if index < len(tokens) else "0"

--- a/backend/tests/test_parse_stats.py
+++ b/backend/tests/test_parse_stats.py
@@ -52,3 +52,13 @@ def test_parse_stats_skips_non_numeric_prefix() -> None:
     assert stats["rebounds"] == 2
     assert stats["assists"] == 3
     assert stats["fgm"] == 7 and stats["fga"] == 14
+
+
+def test_parse_stats_handles_punctuated_numbers() -> None:
+    """Trailing punctuation should not shift subsequent stats."""
+
+    row = "A AUSWEN 17: 2 2 0 0 0 3 7/10 3/4 0/0"
+    stats = parse_stats(row, "AUSWEN")
+    assert stats["points"] == 17
+    assert stats["rebounds"] == 2
+    assert stats["turnovers"] == 3


### PR DESCRIPTION
## Summary
- Strip punctuation and common OCR mistakes before converting stats to integers
- Add regression test for punctuated numbers in parsed box scores

## Testing
- `pip install httpx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af1b96f66483228752121c0df7e19e